### PR TITLE
Relay media deletion errors to snackbar

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -134,6 +134,7 @@ class MediaCollection extends React.Component<Props> {
                     actions={listActions}
                     adapters={mediaListAdapters}
                     onItemClick={onMediaNavigate}
+                    onDeleteError={onDeleteError}
                     ref={mediaListRef}
                     store={mediaListStore}
                 />


### PR DESCRIPTION
Error messages as a result of deletion failure are not relayed to the snackbar in the media overview. This additional prop definition ensures that.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adds the deletion error handler callback to the List rendering statement in the MediaCollection container.

#### Why?

When Media deletion fails in the overview, no error message (not even the generic one) is displayed.

#### Example Usage

Custom Media controllers can now send generic error messages when deletion fails:
```php
return $this->handleView($this->view(['detail' => 'Cannot be deleted due to constraint'], Response::HTTP_BAD_REQUEST));
```